### PR TITLE
updated API path in Swipe component to fix app loading error

### DIFF
--- a/client/src/components/Swipe/index.js
+++ b/client/src/components/Swipe/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, Component } from 'react';
 import "./index.css"
-import API from "../../utils/api"
+import API from "../../Utils/api"
 
 class Swipe extends Component {
 


### PR DESCRIPTION
the app was not loading because the API path in the Swipe component was incorrect. I have fixed it.