### PR TITLE
removed matches and settings tab from Header

### DIFF
--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -19,12 +19,6 @@ const Header = () => {
                 <a href="/profile">Profile</a>
               </li>
               <li>
-                <a href="/matches">Matches</a>
-              </li>
-              <li>
-                <a href="/">Settings</a>
-              </li>
-              <li>
                 <AuthBtn className="btn-flat white-text"/>
               </li>
             </ul>


### PR DESCRIPTION
I've removed the 'Matches' & 'Settings' tab from our Header as discussed 